### PR TITLE
feat: GitHub GraphQL API クライアント実装 (#3)

### DIFF
--- a/lib/exceptions/github_api_exception.dart
+++ b/lib/exceptions/github_api_exception.dart
@@ -1,0 +1,46 @@
+/// GitHub API 関連の例外クラス
+class GitHubApiException implements Exception {
+  final String message;
+  final int? statusCode;
+  final Map<String, dynamic>? graphQLErrors;
+
+  const GitHubApiException(
+    this.message, {
+    this.statusCode,
+    this.graphQLErrors,
+  });
+
+  /// HTTP エラー用の例外
+  factory GitHubApiException.httpError(int statusCode, String message) {
+    return GitHubApiException(
+      'HTTP エラー: $message',
+      statusCode: statusCode,
+    );
+  }
+
+  /// GraphQL エラー用の例外
+  factory GitHubApiException.graphQLError(
+    String message,
+    Map<String, dynamic> errors,
+  ) {
+    return GitHubApiException(
+      'GraphQL エラー: $message',
+      graphQLErrors: errors,
+    );
+  }
+
+  /// トークン未取得エラー用の例外
+  factory GitHubApiException.tokenNotFound() {
+    return const GitHubApiException(
+      'アクセストークンが取得できませんでした。ログインが必要です。',
+    );
+  }
+
+  /// ネットワークエラー用の例外
+  factory GitHubApiException.networkError(String message) {
+    return GitHubApiException('ネットワークエラー: $message');
+  }
+
+  @override
+  String toString() => message;
+}

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -1,8 +1,20 @@
 import 'package:flutter_riverpod/flutter_riverpod.dart';
 import '../repositories/github_repository.dart';
+import '../repositories/github_auth_repository.dart';
 import '../services/github_api_service.dart';
+import '../services/github_graphql_client.dart';
 import '../services/github_oauth_service.dart';
-import '../config/app_config.dart';
+
+/// GitHub 認証リポジトリのプロバイダー
+final githubAuthRepositoryProvider = Provider<GitHubAuthRepository>((ref) {
+  return GitHubAuthRepository();
+});
+
+/// GitHub GraphQL クライアントのプロバイダー
+final githubGraphQLClientProvider = Provider<GitHubGraphQLClient>((ref) {
+  final authRepository = ref.watch(githubAuthRepositoryProvider);
+  return GitHubGraphQLClient(authRepository: authRepository);
+});
 
 /// GitHub OAuth サービスのプロバイダー
 final githubOAuthServiceProvider = Provider<GitHubOAuthService>((ref) {
@@ -11,7 +23,8 @@ final githubOAuthServiceProvider = Provider<GitHubOAuthService>((ref) {
 
 /// GitHub API サービスのプロバイダー
 final githubApiServiceProvider = Provider<GitHubApiService>((ref) {
-  return GitHubApiService();
+  final authRepository = ref.watch(githubAuthRepositoryProvider);
+  return GitHubApiService(authRepository: authRepository);
 });
 
 /// GitHub リポジトリのプロバイダー
@@ -22,6 +35,6 @@ final githubRepositoryProvider = Provider<GitHubRepository>((ref) {
 
 /// 認証状態を管理するプロバイダー
 final authStateProvider = FutureProvider<bool>((ref) async {
-  final token = await AppConfig.getAccessToken();
-  return token != null && token.isNotEmpty;
+  final authRepository = ref.watch(githubAuthRepositoryProvider);
+  return await authRepository.hasAccessToken();
 });

--- a/lib/repositories/github_auth_repository.dart
+++ b/lib/repositories/github_auth_repository.dart
@@ -1,0 +1,31 @@
+import '../config/app_config.dart';
+
+/// GitHub 認証を管理するリポジトリクラス
+class GitHubAuthRepository {
+  /// アクセストークンを取得
+  ///
+  /// 戻り値: アクセストークン（取得できない場合は null）
+  Future<String?> getAccessToken() async {
+    return await AppConfig.getAccessToken();
+  }
+
+  /// アクセストークンを保存
+  ///
+  /// [token] 保存するアクセストークン
+  Future<void> saveAccessToken(String token) async {
+    await AppConfig.saveAccessToken(token);
+  }
+
+  /// アクセストークンを削除
+  Future<void> deleteAccessToken() async {
+    await AppConfig.deleteAccessToken();
+  }
+
+  /// アクセストークンが存在するか確認
+  ///
+  /// 戻り値: トークンが存在する場合は true
+  Future<bool> hasAccessToken() async {
+    final token = await getAccessToken();
+    return token != null && token.isNotEmpty;
+  }
+}

--- a/lib/services/github_graphql_client.dart
+++ b/lib/services/github_graphql_client.dart
@@ -1,0 +1,119 @@
+import 'dart:convert';
+import 'package:http/http.dart' as http;
+import '../config/app_config.dart';
+import '../repositories/github_auth_repository.dart';
+import '../exceptions/github_api_exception.dart';
+
+/// GitHub GraphQL API v4 クライアント
+///
+/// GraphQL query / mutation を実行するための共通クライアントレイヤー
+class GitHubGraphQLClient {
+  final String baseUrl = AppConfig.githubApiBaseUrl;
+  final GitHubAuthRepository _authRepository;
+
+  GitHubGraphQLClient({GitHubAuthRepository? authRepository})
+      : _authRepository = authRepository ?? GitHubAuthRepository();
+
+  /// GraphQL query / mutation を実行
+  ///
+  /// [document] GraphQL query または mutation 文字列
+  /// [variables] クエリ変数（オプション）
+  ///
+  /// 戻り値: APIレスポンスのJSONマップ
+  ///
+  /// 例外: GitHubApiException をスロー
+  Future<Map<String, dynamic>> execute({
+    required String document,
+    Map<String, dynamic>? variables,
+  }) async {
+    // アクセストークンを取得
+    final token = await _authRepository.getAccessToken();
+    if (token == null || token.isEmpty) {
+      throw GitHubApiException.tokenNotFound();
+    }
+
+    try {
+      // GraphQL リクエストを送信
+      final response = await http
+          .post(
+        Uri.parse(baseUrl),
+        headers: {
+          'Content-Type': 'application/json',
+          'Authorization': 'Bearer $token',
+        },
+        body: jsonEncode({
+          'query': document,
+          if (variables != null) 'variables': variables,
+        }),
+      )
+          .timeout(
+        const Duration(seconds: 30),
+        onTimeout: () {
+          throw GitHubApiException.networkError('リクエストがタイムアウトしました');
+        },
+      );
+
+      // HTTP エラーのチェック
+      if (response.statusCode != 200) {
+        throw GitHubApiException.httpError(
+          response.statusCode,
+          response.body,
+        );
+      }
+
+      // JSON レスポンスをパース
+      final jsonResponse = jsonDecode(response.body) as Map<String, dynamic>;
+
+      // GraphQL エラーのチェック
+      if (jsonResponse.containsKey('errors')) {
+        final errors = jsonResponse['errors'] as List<dynamic>;
+        final errorMessages = errors
+            .map((e) => e is Map<String, dynamic> ? e['message'] : e.toString())
+            .join(', ');
+
+        throw GitHubApiException.graphQLError(
+          errorMessages,
+          {'errors': errors},
+        );
+      }
+
+      return jsonResponse;
+    } on GitHubApiException {
+      rethrow;
+    } on FormatException catch (e) {
+      throw GitHubApiException.networkError(
+        'レスポンスのパースに失敗しました: ${e.message}',
+      );
+    } catch (e) {
+      throw GitHubApiException.networkError(
+        '予期しないエラーが発生しました: ${e.toString()}',
+      );
+    }
+  }
+
+  /// GraphQL query を実行
+  ///
+  /// [query] GraphQL query 文字列
+  /// [variables] クエリ変数（オプション）
+  ///
+  /// 戻り値: APIレスポンスのJSONマップ
+  Future<Map<String, dynamic>> query({
+    required String query,
+    Map<String, dynamic>? variables,
+  }) async {
+    return execute(document: query, variables: variables);
+  }
+
+  /// GraphQL mutation を実行
+  ///
+  /// [mutation] GraphQL mutation 文字列
+  /// [variables] ミューテーション変数（オプション）
+  ///
+  /// 戻り値: APIレスポンスのJSONマップ
+  Future<Map<String, dynamic>> mutation({
+    required String mutation,
+    Map<String, dynamic>? variables,
+  }) async {
+    return execute(document: mutation, variables: variables);
+  }
+}


### PR DESCRIPTION
## 概要

GitHub GraphQL API v4 を利用するための共通 GraphQL クライアントレイヤーを実装しました。

## 実装内容

### 1. GitHubApiException
- HTTP エラー、GraphQL エラー、トークン未取得、ネットワークエラーに対応するカスタム例外クラス

### 2. GitHubAuthRepository
- SecureStorage からのアクセストークン取得・保存・削除を管理
- AppConfig をラップして認証処理を分離

### 3. GitHubGraphQLClient
- GitHub GraphQL API v4 の共通クライアント
- `execute()` メソッドで query/mutation を統合
- `query()` と `mutation()` メソッドを提供
- エラーハンドリング:
  - トークン未取得時のエラー
  - HTTP エラー（ステータスコード）
  - GraphQL errors（レスポンス内の errors フィールド）
  - ネットワークエラー（タイムアウト、パースエラー）

### 4. 既存コードの更新
- GitHubApiService を新しい GitHubGraphQLClient を使用するように更新（後方互換性を維持）
- プロバイダーを更新して新しいクラスを使用

## 完了条件の確認

- ✅ GraphQL query を実行できる
- ✅ Authorization Header が付与されている
- ✅ エラー時に例外が投げられる
- ✅ 次 Issue で query を追加できる構成になっている

## 関連 Issue

Closes #3