### PR TITLE
feat: Project詳細取得（fields / items）を実装

### DIFF
--- a/lib/models/project_detail.dart
+++ b/lib/models/project_detail.dart
@@ -290,9 +290,12 @@ class ProjectItem {
   /// Statusフィールドの値を取得
   String? getStatusValue() {
     for (final fieldValue in fieldValues) {
-      if (fieldValue.field?.name.toLowerCase() == 'status' ||
-          fieldValue.field?.name.toLowerCase() == 'ステータス') {
-        return fieldValue.value;
+      final field = fieldValue.field;
+      if (field != null) {
+        final fieldName = field.name.toLowerCase();
+        if (fieldName == 'status' || fieldName == 'ステータス') {
+          return fieldValue.value;
+        }
       }
     }
     return null;
@@ -301,9 +304,12 @@ class ProjectItem {
   /// Dateフィールドの値を取得
   String? getDateValue() {
     for (final fieldValue in fieldValues) {
-      if (fieldValue.field?.name.toLowerCase() == 'date' ||
-          fieldValue.field?.name.toLowerCase() == '日付') {
-        return fieldValue.value;
+      final field = fieldValue.field;
+      if (field != null) {
+        final fieldName = field.name.toLowerCase();
+        if (fieldName == 'date' || fieldName == '日付') {
+          return fieldValue.value;
+        }
       }
     }
     return null;

--- a/lib/models/project_detail.dart
+++ b/lib/models/project_detail.dart
@@ -1,0 +1,418 @@
+/// GitHub Project (Projects v2) の詳細情報を表すモデルクラス
+class ProjectDetail {
+  /// プロジェクトID
+  final String id;
+
+  /// プロジェクトのフィールド一覧
+  final List<ProjectField> fields;
+
+  /// プロジェクトのアイテム一覧
+  final List<ProjectItem> items;
+
+  ProjectDetail({
+    required this.id,
+    required this.fields,
+    required this.items,
+  });
+
+  /// JSONからProjectDetailインスタンスを作成
+  factory ProjectDetail.fromJson(Map<String, dynamic> json) {
+    if (json['id'] == null || json['id'] is! String) {
+      throw const FormatException('Missing or invalid "id" field');
+    }
+
+    final fieldsJson = json['fields'] as Map<String, dynamic>?;
+    final fields = <ProjectField>[];
+    if (fieldsJson != null) {
+      final nodes = fieldsJson['nodes'] as List<dynamic>?;
+      if (nodes != null) {
+        for (final node in nodes) {
+          if (node != null) {
+            try {
+              fields.add(ProjectField.fromJson(node as Map<String, dynamic>));
+            } catch (e) {
+              // パースエラーは無視して続行
+            }
+          }
+        }
+      }
+    }
+
+    final itemsJson = json['items'] as Map<String, dynamic>?;
+    final items = <ProjectItem>[];
+    if (itemsJson != null) {
+      final nodes = itemsJson['nodes'] as List<dynamic>?;
+      if (nodes != null) {
+        for (final node in nodes) {
+          if (node != null) {
+            try {
+              items.add(ProjectItem.fromJson(node as Map<String, dynamic>));
+            } catch (e) {
+              // パースエラーは無視して続行
+            }
+          }
+        }
+      }
+    }
+
+    return ProjectDetail(
+      id: json['id'] as String,
+      fields: fields,
+      items: items,
+    );
+  }
+
+  /// ProjectDetailインスタンスをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'fields': {
+        'nodes': fields.map((f) => f.toJson()).toList(),
+      },
+      'items': {
+        'nodes': items.map((i) => i.toJson()).toList(),
+      },
+    };
+  }
+
+  /// Statusフィールドを取得
+  ProjectField? get statusField {
+    try {
+      return fields.firstWhere(
+        (field) =>
+            field.dataType == 'SINGLE_SELECT' &&
+            (field.name.toLowerCase() == 'status' ||
+                field.name.toLowerCase() == 'ステータス'),
+      );
+    } catch (e) {
+      return null;
+    }
+  }
+
+  /// Dateフィールドを取得
+  ProjectField? get dateField {
+    try {
+      return fields.firstWhere(
+        (field) =>
+            field.dataType == 'DATE' &&
+            (field.name.toLowerCase() == 'date' ||
+                field.name.toLowerCase() == '日付'),
+      );
+    } catch (e) {
+      return null;
+    }
+  }
+}
+
+/// プロジェクトのフィールド
+class ProjectField {
+  /// フィールドID
+  final String id;
+
+  /// フィールド名
+  final String name;
+
+  /// データタイプ（SINGLE_SELECT, DATE, TEXT など）
+  final String dataType;
+
+  /// オプション（Single Select フィールドの場合）
+  final List<ProjectFieldOption>? options;
+
+  ProjectField({
+    required this.id,
+    required this.name,
+    required this.dataType,
+    this.options,
+  });
+
+  /// JSONからProjectFieldインスタンスを作成
+  factory ProjectField.fromJson(Map<String, dynamic> json) {
+    if (json['id'] == null || json['id'] is! String) {
+      throw const FormatException('Missing or invalid "id" field');
+    }
+    if (json['name'] == null || json['name'] is! String) {
+      throw const FormatException('Missing or invalid "name" field');
+    }
+    if (json['dataType'] == null || json['dataType'] is! String) {
+      throw const FormatException('Missing or invalid "dataType" field');
+    }
+
+    final options = <ProjectFieldOption>[];
+    if (json['options'] != null) {
+      final optionsJson = json['options'] as List<dynamic>?;
+      if (optionsJson != null) {
+        for (final optionJson in optionsJson) {
+          if (optionJson != null) {
+            try {
+              options.add(ProjectFieldOption.fromJson(
+                  optionJson as Map<String, dynamic>));
+            } catch (e) {
+              // パースエラーは無視して続行
+            }
+          }
+        }
+      }
+    }
+
+    return ProjectField(
+      id: json['id'] as String,
+      name: json['name'] as String,
+      dataType: json['dataType'] as String,
+      options: options.isNotEmpty ? options : null,
+    );
+  }
+
+  /// ProjectFieldインスタンスをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+      'dataType': dataType,
+      if (options != null) 'options': options!.map((o) => o.toJson()).toList(),
+    };
+  }
+
+  /// Single Select フィールドかどうか
+  bool get isSingleSelect => dataType == 'SINGLE_SELECT';
+
+  /// Date フィールドかどうか
+  bool get isDate => dataType == 'DATE';
+}
+
+/// プロジェクトフィールドのオプション（Single Select 用）
+class ProjectFieldOption {
+  /// オプションID
+  final String id;
+
+  /// オプション名
+  final String name;
+
+  ProjectFieldOption({
+    required this.id,
+    required this.name,
+  });
+
+  /// JSONからProjectFieldOptionインスタンスを作成
+  factory ProjectFieldOption.fromJson(Map<String, dynamic> json) {
+    if (json['id'] == null || json['id'] is! String) {
+      throw const FormatException('Missing or invalid "id" field');
+    }
+    if (json['name'] == null || json['name'] is! String) {
+      throw const FormatException('Missing or invalid "name" field');
+    }
+    return ProjectFieldOption(
+      id: json['id'] as String,
+      name: json['name'] as String,
+    );
+  }
+
+  /// ProjectFieldOptionインスタンスをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'name': name,
+    };
+  }
+}
+
+/// プロジェクトのアイテム
+class ProjectItem {
+  /// アイテムID
+  final String id;
+
+  /// フィールド値の一覧
+  final List<ProjectItemFieldValue> fieldValues;
+
+  /// コンテンツ（Issue または Draft）
+  final ProjectItemContent? content;
+
+  ProjectItem({
+    required this.id,
+    required this.fieldValues,
+    this.content,
+  });
+
+  /// JSONからProjectItemインスタンスを作成
+  factory ProjectItem.fromJson(Map<String, dynamic> json) {
+    if (json['id'] == null || json['id'] is! String) {
+      throw const FormatException('Missing or invalid "id" field');
+    }
+
+    final fieldValues = <ProjectItemFieldValue>[];
+    final fieldValuesJson = json['fieldValues'] as Map<String, dynamic>?;
+    if (fieldValuesJson != null) {
+      final nodes = fieldValuesJson['nodes'] as List<dynamic>?;
+      if (nodes != null) {
+        for (final node in nodes) {
+          if (node != null) {
+            try {
+              fieldValues.add(
+                  ProjectItemFieldValue.fromJson(node as Map<String, dynamic>));
+            } catch (e) {
+              // パースエラーは無視して続行
+            }
+          }
+        }
+      }
+    }
+
+    ProjectItemContent? content;
+    final contentJson = json['content'] as Map<String, dynamic>?;
+    if (contentJson != null) {
+      try {
+        content = ProjectItemContent.fromJson(contentJson);
+      } catch (e) {
+        // パースエラーは無視
+      }
+    }
+
+    return ProjectItem(
+      id: json['id'] as String,
+      fieldValues: fieldValues,
+      content: content,
+    );
+  }
+
+  /// ProjectItemインスタンスをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'fieldValues': {
+        'nodes': fieldValues.map((fv) => fv.toJson()).toList(),
+      },
+      if (content != null) 'content': content!.toJson(),
+    };
+  }
+
+  /// タイトルを取得
+  String? get title => content?.title;
+
+  /// Statusフィールドの値を取得
+  String? getStatusValue() {
+    for (final fieldValue in fieldValues) {
+      if (fieldValue.field?.name.toLowerCase() == 'status' ||
+          fieldValue.field?.name.toLowerCase() == 'ステータス') {
+        return fieldValue.value;
+      }
+    }
+    return null;
+  }
+
+  /// Dateフィールドの値を取得
+  String? getDateValue() {
+    for (final fieldValue in fieldValues) {
+      if (fieldValue.field?.name.toLowerCase() == 'date' ||
+          fieldValue.field?.name.toLowerCase() == '日付') {
+        return fieldValue.value;
+      }
+    }
+    return null;
+  }
+}
+
+/// プロジェクトアイテムのフィールド値
+class ProjectItemFieldValue {
+  /// フィールド情報
+  final ProjectField? field;
+
+  /// 値（Single Select の場合は name、Date の場合は date）
+  final String? value;
+
+  ProjectItemFieldValue({
+    this.field,
+    this.value,
+  });
+
+  /// JSONからProjectItemFieldValueインスタンスを作成
+  factory ProjectItemFieldValue.fromJson(Map<String, dynamic> json) {
+    ProjectField? field;
+    final fieldJson = json['field'] as Map<String, dynamic>?;
+    if (fieldJson != null) {
+      try {
+        field = ProjectField.fromJson(fieldJson);
+      } catch (e) {
+        // パースエラーは無視
+      }
+    }
+
+    String? value;
+    // Single Select の場合
+    if (json.containsKey('name') && json['name'] != null) {
+      value = json['name'] as String?;
+    }
+    // Date の場合
+    if (json.containsKey('date') && json['date'] != null) {
+      value = json['date'] as String?;
+    }
+
+    return ProjectItemFieldValue(
+      field: field,
+      value: value,
+    );
+  }
+
+  /// ProjectItemFieldValueインスタンスをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      if (field != null) 'field': field!.toJson(),
+      if (value != null) 'value': value,
+    };
+  }
+}
+
+/// プロジェクトアイテムのコンテンツ（Issue または Draft）
+class ProjectItemContent {
+  /// タイトル
+  final String? title;
+
+  /// Issue の場合の番号
+  final int? number;
+
+  /// Issue の場合の状態（OPEN, CLOSED）
+  final String? state;
+
+  /// コンテンツタイプ（Issue または Draft）
+  final String type;
+
+  ProjectItemContent({
+    this.title,
+    this.number,
+    this.state,
+    required this.type,
+  });
+
+  /// JSONからProjectItemContentインスタンスを作成
+  factory ProjectItemContent.fromJson(Map<String, dynamic> json) {
+    // Issue の場合
+    if (json.containsKey('number') || json.containsKey('state')) {
+      return ProjectItemContent(
+        title: json['title'] as String?,
+        number: json['number'] as int?,
+        state: json['state'] as String?,
+        type: 'Issue',
+      );
+    }
+
+    // Draft の場合（将来の拡張用）
+    return ProjectItemContent(
+      title: json['title'] as String?,
+      type: 'Draft',
+    );
+  }
+
+  /// ProjectItemContentインスタンスをJSONに変換
+  Map<String, dynamic> toJson() {
+    return {
+      if (title != null) 'title': title,
+      if (number != null) 'number': number,
+      if (state != null) 'state': state,
+      'type': type,
+    };
+  }
+
+  /// Issue かどうか
+  bool get isIssue => type == 'Issue';
+
+  /// Draft かどうか
+  bool get isDraft => type == 'Draft';
+}

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -6,6 +6,7 @@ import '../services/github_api_service.dart';
 import '../services/github_graphql_client.dart';
 import '../services/github_app_service.dart';
 import '../models/project.dart';
+import '../models/project_detail.dart';
 
 /// GitHub App サービスのプロバイダー
 final githubAppServiceProvider = Provider<GitHubAppService>((ref) {
@@ -61,3 +62,14 @@ final projectsProvider = FutureProvider<List<Project>>((ref) async {
   final repository = ref.watch(githubRepositoryProvider);
   return await repository.getProjects();
 });
+
+/// プロジェクト詳細を管理するプロバイダー
+/// Loading / Success / Error の状態を自動的に管理
+///
+/// [projectId] プロジェクトID
+final projectDetailProvider = FutureProvider.family<ProjectDetail, String>(
+  (ref, projectId) async {
+    final repository = ref.watch(githubRepositoryProvider);
+    return await repository.getProjectDetails(projectId);
+  },
+);

--- a/lib/services/github_api_service.dart
+++ b/lib/services/github_api_service.dart
@@ -250,4 +250,80 @@ class GitHubApiService {
       return await _graphQLClient.query(query: query);
     }
   }
+
+  /// Project の詳細情報（fields / items）を取得
+  ///
+  /// [projectId] プロジェクトID
+  ///
+  /// 戻り値: APIレスポンスのJSONマップ
+  Future<Map<String, dynamic>> getProjectDetail({
+    required String projectId,
+  }) async {
+    const query = '''
+      query ProjectDetail(\$projectId: ID!) {
+        node(id: \$projectId) {
+          ... on ProjectV2 {
+            id
+            fields(first: 20) {
+              nodes {
+                id
+                name
+                dataType
+                ... on ProjectV2SingleSelectField {
+                  options {
+                    id
+                    name
+                  }
+                }
+              }
+            }
+            items(first: 50) {
+              nodes {
+                id
+                fieldValues(first: 20) {
+                  nodes {
+                    ... on ProjectV2ItemFieldSingleSelectValue {
+                      field {
+                        ... on ProjectV2Field {
+                          id
+                          name
+                          dataType
+                        }
+                      }
+                      name
+                    }
+                    ... on ProjectV2ItemFieldDateValue {
+                      date
+                      field {
+                        ... on ProjectV2Field {
+                          id
+                          name
+                          dataType
+                        }
+                      }
+                    }
+                  }
+                }
+                content {
+                  ... on Issue {
+                    title
+                    number
+                    state
+                  }
+                  ... on DraftIssue {
+                    title
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    ''';
+
+    return await _graphQLClient.query(
+      query: query,
+      variables: {'projectId': projectId},
+    );
+  }
 }


### PR DESCRIPTION
## 概要
Issue #10 の実装です。GitHub Project（Projects v2）の詳細情報（fields / items）を GraphQL API で取得できるようにしました。

## 実装内容

### 1. ProjectDetailモデルの作成
- `lib/models/project_detail.dart` を新規作成
- `ProjectDetail`: プロジェクトの詳細情報（fields, items）
- `ProjectField`: フィールド情報（Single Select / Date）
- `ProjectItem`: アイテム情報（Issue / Draft）
- `ProjectItemFieldValue`: フィールド値
- `ProjectItemContent`: コンテンツ（Issue / Draft）
- `statusField` / `dateField` のgetterでStatus/Dateフィールドを識別可能

### 2. GitHubApiServiceにメソッド追加
- `getProjectDetail` メソッドを追加
- Issueで指定されたGraphQLクエリを使用してプロジェクト詳細を取得

### 3. GitHubRepositoryの実装
- `getProjectDetails` メソッドを実装
- APIレスポンスを `ProjectDetail` モデルに変換
- エラーハンドリングを追加

### 4. プロバイダーの追加
- `projectDetailProvider` を追加
- Riverpodの `FutureProvider.family` を使用してプロジェクトIDごとに状態管理（loading / success / error）

## 完了条件（DoD）
- ✅ Project fieldsが取得できる
- ✅ Project itemsが取得できる
- ✅ Status / Date fieldを識別できる

Closes #10