### PR TITLE
feat: Project Items を Status 別に分類する機能を実装

### DIFF
--- a/lib/models/project_detail.dart
+++ b/lib/models/project_detail.dart
@@ -102,6 +102,26 @@ class ProjectDetail {
       return null;
     }
   }
+
+  /// Status別にitemsを分類する
+  ///
+  /// 戻り値: Status名をキー、そのStatusに属するitemsのリストを値とするMap
+  /// Statusが未設定のitemsは"No Status"として分類される
+  Map<String, List<ProjectItem>> groupItemsByStatus() {
+    final groupedItems = <String, List<ProjectItem>>{};
+
+    for (final item in items) {
+      final statusValue = item.getStatusValue();
+      final statusKey = statusValue ?? 'No Status';
+
+      if (!groupedItems.containsKey(statusKey)) {
+        groupedItems[statusKey] = <ProjectItem>[];
+      }
+      groupedItems[statusKey]!.add(item);
+    }
+
+    return groupedItems;
+  }
 }
 
 /// プロジェクトのフィールド

--- a/lib/providers/app_providers.dart
+++ b/lib/providers/app_providers.dart
@@ -73,3 +73,17 @@ final projectDetailProvider = FutureProvider.family<ProjectDetail, String>(
     return await repository.getProjectDetails(projectId);
   },
 );
+
+/// Status別に分類されたプロジェクトアイテムを管理するプロバイダー
+/// Loading / Success / Error の状態を自動的に管理
+///
+/// [projectId] プロジェクトID
+/// 戻り値: Status名をキー、そのStatusに属するitemsのリストを値とするMap
+final projectItemsGroupedByStatusProvider =
+    FutureProvider.family<Map<String, List<ProjectItem>>, String>(
+  (ref, projectId) async {
+    final projectDetail =
+        await ref.watch(projectDetailProvider(projectId).future);
+    return projectDetail.groupItemsByStatus();
+  },
+);


### PR DESCRIPTION
## 概要
取得した Project items を **Status field の値ごとに分類**するロジックを実装しました。

## 実装内容
- `ProjectDetail` クラスに `groupItemsByStatus()` メソッドを追加
- Status 未設定の items は 'No Status' として分類
- `projectItemsGroupedByStatusProvider` を追加して UI から参照可能に

## 変更ファイル
- `lib/models/project_detail.dart`: Status別分類メソッドを追加
- `lib/providers/app_providers.dart`: Status別分類プロバイダーを追加

## 完了条件
- ✅ Status 別に items が分類される
- ✅ UI から参照できる状態になっている

Closes #11